### PR TITLE
Auto-save local robustness counterexamples

### DIFF
--- a/verification/robustness.ipynb
+++ b/verification/robustness.ipynb
@@ -9,13 +9,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "from utils import TOTUtils\n",
     "\n",
-    "samples = TOTUtils.load_samples('../data/latest/train.csv', frac=1)"
+    "samples = TOTUtils.load_samples('../data/latest/verification.csv', frac=0.02)"
    ]
   },
   {
@@ -27,13 +27,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": 3,
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "output_type": "stream",
      "name": "stderr",
-     "text": "INFO:robustness:searching 9 coarse epsilons b/t 1e-06 and 9e-06\nINFO:robustness:searching 9 coarse epsilons b/t 1e-05 and 9e-05\nINFO:robustness:searching 9 coarse epsilons b/t 0.0001 and 0.0009\nINFO:robustness:searching 9 coarse epsilons b/t 0.001 and 0.009\nINFO:robustness:searching 9 coarse epsilons b/t 0.01 and 0.09\nINFO:robustness:s0 coarse epsilon bounds: (0.01, 0.02) (2242ms)\nINFO:robustness:searching 1000 epsilons b/t 0.01 and 0.01999\nINFO:robustness:s0 epsilon: 0.01606 (1115ms)\nINFO:robustness:searching 9 coarse epsilons b/t 1e-06 and 9e-06\nINFO:robustness:searching 9 coarse epsilons b/t 1e-05 and 9e-05\nINFO:robustness:searching 9 coarse epsilons b/t 0.0001 and 0.0009\nINFO:robustness:searching 9 coarse epsilons b/t 0.001 and 0.009\nINFO:robustness:s1 coarse epsilon bounds: (0.005, 0.006) (1847ms)\nINFO:robustness:searching 100 epsilons b/t 0.005 and 0.00599\nINFO:robustness:s1 epsilon: 0.00533 (535ms)\nINFO:robustness:local robustness: (-0.00533, 0.00533) (5743ms)\nINFO:robustness:wrote summary to ../logs/test/robustness/symmetric/local_summary.csv\nINFO:robustness:wrote detils to ../logs/test/robustness/symmetric/local_details.csv\nINFO:robustness:searching 9 coarse l_epsilons b/t 1e-06 and 9e-06\nINFO:robustness:searching 9 coarse l_epsilons b/t 1e-05 and 9e-05\nINFO:robustness:searching 9 coarse l_epsilons b/t 0.0001 and 0.0009\nINFO:robustness:searching 9 coarse l_epsilons b/t 0.001 and 0.009\nINFO:robustness:searching 9 coarse l_epsilons b/t 0.01 and 0.09\nINFO:robustness:s0 lower epsilon coarse bounds: (0.04, 0.05) (2729ms)\nINFO:robustness:searching 9 coarse u_epsilons b/t 1e-06 and 9e-06\nINFO:robustness:searching 9 coarse u_epsilons b/t 1e-05 and 9e-05\nINFO:robustness:searching 9 coarse u_epsilons b/t 0.0001 and 0.0009\nINFO:robustness:searching 9 coarse u_epsilons b/t 0.001 and 0.009\nINFO:robustness:searching 9 coarse u_epsilons b/t 0.01 and 0.09\nINFO:robustness:s0 upper epsilon coarse bounds: (0.02, 0.03) (2067ms)\nINFO:robustness:searching 1001 l_epsilons b/t 0.04 and 0.05\nINFO:robustness:s0 lower epsilon: 0.04164 (2602ms)\nINFO:robustness:searching 1000 u_epsilons b/t 0.02 and 0.02999\nINFO:robustness:s0 upper epsilon: 0.02475 (926ms)\nINFO:robustness:searching 9 coarse l_epsilons b/t 1e-06 and 9e-06\nINFO:robustness:searching 9 coarse l_epsilons b/t 1e-05 and 9e-05\nINFO:robustness:searching 9 coarse l_epsilons b/t 0.0001 and 0.0009\nINFO:robustness:searching 9 coarse l_epsilons b/t 0.001 and 0.009\nINFO:robustness:s1 lower epsilon coarse bounds: (0.007, 0.008) (2009ms)\nINFO:robustness:searching 9 coarse u_epsilons b/t 1e-06 and 9e-06\nINFO:robustness:searching 9 coarse u_epsilons b/t 1e-05 and 9e-05\nINFO:robustness:searching 9 coarse u_epsilons b/t 0.0001 and 0.0009\nINFO:robustness:searching 9 coarse u_epsilons b/t 0.001 and 0.009\nINFO:robustness:s1 upper epsilon coarse bounds: (0.006, 0.007) (1852ms)\nINFO:robustness:searching 100 l_epsilons b/t 0.007 and 0.00799\nINFO:robustness:s1 lower epsilon: 0.0072 (795ms)\nINFO:robustness:searching 100 u_epsilons b/t 0.006 and 0.00699\nINFO:robustness:s1 upper epsilon: 0.00606 (461ms)\nINFO:robustness:asymm local robustness: (-0.0072, 0.00606) (13445ms)\nINFO:robustness:wrote summary to ../logs/test/robustness/asymmetric/local_summary.csv\nINFO:robustness:wrote detils to ../logs/test/robustness/asymmetric/local_details.csv\nSymmetric results:  ((-0.00533, 0.00533), [(0.01606, 0.01606), (0.00533, 0.00533)])\nAsymmetric results:  ((-0.0072, 0.00606), [(0.04164, 0.02475), (0.0072, 0.00606)])\n"
+     "text": "INFO:robustness:searching 9 coarse epsilons b/t 1e-06 and 9e-06\nINFO:robustness:searching 9 coarse epsilons b/t 1e-05 and 9e-05\nINFO:robustness:searching 9 coarse epsilons b/t 0.0001 and 0.0009\nINFO:robustness:searching 9 coarse epsilons b/t 0.001 and 0.009\nINFO:robustness:searching 9 coarse epsilons b/t 0.01 and 0.09\nINFO:robustness:s0 coarse epsilon bounds: (0.08, 0.09) (85195ms)\nINFO:robustness:searching 1000 epsilons b/t 0.08 and 0.08999\nINFO:robustness:s0 epsilon: 0.0817 (245465ms)\nINFO:robustness:searching 9 coarse epsilons b/t 1e-06 and 9e-06\nINFO:robustness:searching 9 coarse epsilons b/t 1e-05 and 9e-05\nINFO:robustness:searching 9 coarse epsilons b/t 0.0001 and 0.0009\nINFO:robustness:searching 9 coarse epsilons b/t 0.001 and 0.009\nINFO:robustness:searching 9 coarse epsilons b/t 0.01 and 0.09\nINFO:robustness:s1 coarse epsilon bounds: (0.03, 0.04) (2955ms)\nINFO:robustness:searching 1001 epsilons b/t 0.03 and 0.04\nINFO:robustness:s1 epsilon: 0.03648 (9934ms)\nINFO:robustness:local robustness: (-0.03648, 0.03648) (343549ms)\nINFO:robustness:wrote summary to ../logs/test/robustness/symmetric/local_summary.csv\nINFO:robustness:wrote detils to ../logs/test/robustness/symmetric/local_details.csv\nSymmetric results:  ((-0.03648, 0.03648), [(0.0817, 0.0817, (([-0.28055283896096617, 0.9046338345003357, 1.7887553951068855, 2.3521738442404323, 0.5410091074018608, 0.36470371451870076, 0.6127366460981567, -0.24894141358835453, 0.8674947889049851, 1.2753682006443163, 0.4970745454315475, 0.79025434103912, -0.10131896818646297, 0.6574468039358837, 0.021861306301013503, 0.11126577908206405, 0.531607630194766, -0.04252305809637558, -0.2494496045601684, 0.7106493868752928, -0.1277166470489478, 0.09899927942827094, 0.26620958004575423, 0.06728721536249774, -0.08060216451525691], [-29.233311173432906, -6.637652158166571, -37.46333117050721, -6.637652158166571, -33.22212710674304]), <maraboupy.MarabouCore.Statistics object at 0x17ae172f0>)), (0.03648, 0.03648, (([0.5391378565926169, 0.15418119999905147, 0.4990202040521759, 0.3390245541500618, -0.513453216374009, 0.5194129527770446, 0.5500226692357129, -0.021646364591924504, -0.10490519201475246, 0.5183241278037071, 0.0038786781006895157, 0.83547434103912, 0.016901031813537037, 0.6143001905112089, -0.0233586936989865, 1.242223718504337, 0.07056703965320257, -0.08774305809637559, -0.13122960456016838, 0.26611724143345666, -0.018564493109556976, 0.05377927942827093, 0.1823104028931566, 0.022067215362497727, -0.1258221645152569], [1.8740596974085668, 11.4212831259869, 11.4212831259869, -1.126872890334267, -12.078796131913553]), <maraboupy.MarabouCore.Statistics object at 0x17ae27370>))])\n"
     }
    ],
    "source": [
@@ -51,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Run Asymmetric Local Robustness"
+    "## Run Asymmetric Local Robustness (Deprecated - wasn't useful)"
    ]
   },
   {
@@ -75,15 +77,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": "INFO:robustness:s1 ok (-0.00533, 0.00533)\nINFO:robustness:s1 ok (-0.0072, 0.00606)\nSymmetric check results: {'s0': None, 's1': None}\nAsymmetric check results: {'s0': (None, None), 's1': (None, None)}\n"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from robustness import check_local_robustness\n",
     "\n",


### PR DESCRIPTION
The local robustness counterexamples were not being saved automatically,
So, updated local robustness to do this automatically when the
"save_results" flag is set to true.

Also, fixed distance metric for the cluster-based robustness. That code got 
out of date with the master branch, but is fixed now.

Also, added deprecation note about asymmetric local robustness... we found
that it wasn't really a useful method of verification, so it can be removed soon.